### PR TITLE
Add filter for response before the request. 

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,4 @@ parameters:
 		- src/
 
 	checkGenericClassInNonGenericObjectType: false
+	treatPhpDocTypesAsCertain: false


### PR DESCRIPTION
This PR:
* Adds the `wp_proxy_service_response_before_request` to filter a response before the request is made, providing a way to short circuit the request. For example, this can be used to add a caching layer.
* Renames the filter `wp_proxy_service_response` to `wp_proxy_service_response_after_request`.
* Increases the destination request timeout to 3 seconds.